### PR TITLE
色相のrotate()をHSL色空間ではなくLCH色空間で行えるオプションを追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Available functions
 | `isLight(color) -> boolean` | Detect light or not |
 | `mix(color1, color2) -> string` | mix colors |
 | `parse(-) -> Object` | Parse a color |
-| `rotate(color, degree) -> string` | rotate color |
+| `rotate(color, degree, options) -> string` | rotate color |
 
 
 <!-- Section from "doc/guides/03.Functions.md.hbs" End -->

--- a/lib/rotate.js
+++ b/lib/rotate.js
@@ -3,6 +3,7 @@
  * @function rotate
  * @param {string} color - Color value.
  * @param {number} degree to rotate. 0 to 360
+ * @param {Object} [options={}] - Optional settings
  * @returns {string}
  */
 'use strict'
@@ -10,8 +11,18 @@
 const parse = require('./parse')
 
 /** @lends rotate */
-function rotate (color, degree) {
-  return parse(color).rotate(Number(degree)).string()
+function rotate (color, degree, options = {}) {
+  const { lch = false } = options
+  if (lch) {
+    const parsed = parse(color).lch()
+    let hue = parsed.color[2]
+    hue = (hue + degree) % 360;
+    hue = hue < 0 ? 360 + hue : hue;
+    parsed.color[2] = hue;
+    return parsed.string()
+  } else {
+    return parse(color).rotate(Number(degree)).string()
+  }
 }
 
 module.exports = rotate

--- a/test/rotate_test.js
+++ b/test/rotate_test.js
@@ -21,6 +21,13 @@ describe('rotate', () => {
     assert.equal(rotate('#AA1', 30), 'hsl(90, 81.8%, 36.7%)')
     assert.equal(rotate('#AA1', 120), 'hsl(180, 81.8%, 36.7%)')
   })
+
+  it('Rotate in LCH color space', async () => {
+    assert.equal(rotate('rgb(170, 170, 17)', 0, { lch: true }), 'rgb(170, 170, 17)')
+    assert.equal(rotate('rgb(170, 170, 17)', 360, { lch: true }), 'rgb(170, 170, 17)')
+    assert.equal(rotate('rgb(170, 170, 17)', -360, { lch: true }), 'rgb(170, 170, 17)')
+    assert.equal(rotate('rgb(170, 170, 17)', 20, { lch: true }), 'rgb(126, 180, 48)')
+  })
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
@okunishinishi 

色相の回転はLCH色空間で行ったほうが人間の知覚には自然に見えるため。

参考: https://qiita.com/fujiharuka/items/3a9b0eaeda7ffde70df3